### PR TITLE
Summary loading optimization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "description": "N/A",
     "type": "magento2-module",
     "require": {
-        "magento/magento2-base": "^2.3.1"
+        "magento/magento2-base": "^2.3.1",
+        "scandipwa/catalog-graphql": "^2.2.0"
     },
     "support": {
         "source": "https://github.com/scandipwa/reviews-graphql",

--- a/src/Model/Resolver/Product/ReviewSummary.php
+++ b/src/Model/Resolver/Product/ReviewSummary.php
@@ -31,11 +31,6 @@ use Magento\Store\Model\StoreManagerInterface;
 class ReviewSummary implements ResolverInterface
 {
     /**
-     * @var ReviewFactory
-     */
-    protected $reviewFactory;
-
-    /**
      * @var StoreManagerInterface
      */
     protected $storeManager;
@@ -43,14 +38,11 @@ class ReviewSummary implements ResolverInterface
     /**
      * ReviewSummary constructor.
      *
-     * @param ReviewFactory $reviewFactory
      * @param StoreManagerInterface $storeManager
      */
     public function __construct(
-        ReviewFactory $reviewFactory,
         StoreManagerInterface $storeManager
     ) {
-        $this->reviewFactory = $reviewFactory;
         $this->storeManager = $storeManager;
     }
 
@@ -70,14 +62,11 @@ class ReviewSummary implements ResolverInterface
 
         /** @var Product $product */
         $product = $value['model'];
-        $storeId = $this->storeManager->getStore()->getId();
-        $this->reviewFactory->create()->getEntitySummary($product, $storeId);
-        $ratingSummary = $product->getRatingSummary()->getRatingSummary();
-        $reviewCount = $product->getRatingSummary()->getReviewsCount();
+        $ratingSummary = $product->getRatingSummary();
 
         return [
-            'rating_summary' => $ratingSummary,
-            'review_count' => $reviewCount
+            'rating_summary' => $ratingSummary->getRatingSummary(),
+            'review_count' => $ratingSummary->getReviewsCount()
         ];
     }
 }


### PR DESCRIPTION
Took summary from collection, instead of loading it each time. 

In order to achieve this I am appending them in `catalog-graphql` on load of the collection. This saves a lot of time.

**TODO: add dependecy to catalog-graphql**. Depends on PR: https://github.com/scandipwa/catalog-graphql/pull/24