### PR TITLE
[SWPWA-382] fix Rating Attribute Title does not use store view value

### DIFF
--- a/src/Model/Resolver/GetRatings.php
+++ b/src/Model/Resolver/GetRatings.php
@@ -73,7 +73,8 @@ class GetRatings implements ResolverInterface
         array $args = null
     ) {
         $ratingData = [];
-        $ratings = $this->ratingCollection->addOptionToItems()->getItems();
+        $currentStoreId = $this->storeManager->getStore()->getId();
+        $ratings = $this->ratingCollection->addRatingPerStoreName($currentStoreId)->addOptionToItems()->getItems();
 
         /**
          * @var Rating $rating


### PR DESCRIPTION
Now Rating Attribute Title supports store view values
![Selection_158](https://user-images.githubusercontent.com/53301511/72683396-aa72f500-3adf-11ea-9c4a-d30f635964ad.png)
